### PR TITLE
Correct error in calling _levels.getFloorsForPoint

### DIFF
--- a/scripts/levels.js
+++ b/scripts/levels.js
@@ -1619,7 +1619,7 @@ class Levels {
 
   getFloorsForPoint(point) {
     let cPoint = { center: { x: point.x, y: point.y } };
-    return findRoomsTiles(cPoint, this.levelsTiles);
+    return this.findRoomsTiles(cPoint, this.levelsTiles);
   }
 
   /**


### PR DESCRIPTION
Calling `_levels.getFloorsForPoint` throws an error that `findRoomsTiles` is undefined. I think it is missing `this`.