### PR TITLE
Refactor Decision to Ignore a Wall into a Function

### DIFF
--- a/scripts/levels.js
+++ b/scripts/levels.js
@@ -1972,7 +1972,7 @@ class Levels {
       for (let wall of canvas.walls.placeables) {
         if (_levels.shouldIgnoreWall(wall, TYPE)) continue;
 
-        let isTerrain = wall.data.sight === CONST.WALL_SENSE_TYPES.LIMITED;
+        let isTerrain = TYPE === 0 && wall.data.sight === CONST.WALL_SENSE_TYPES.LIMITED;
 
         //declare points in 3d space of the rectangle created by the wall
         const wallBotTop = getWallHeightRange3Dcollision(wall);

--- a/scripts/levels.js
+++ b/scripts/levels.js
@@ -1857,6 +1857,17 @@ class Levels {
   }
 
   /**
+  * Check whether the given wall should be tested for collisions
+  */
+   shouldIgnoreWall(wall, collisionType) {
+    if (collisionType === 0) {
+      return wall.data.sight === CONST.WALL_SENSE_TYPES.NONE || (wall.data.door != 0 && wall.data.ds === 1)
+    } else if (collisionType === 1) {
+      return wall.data.move === CONST.WALL_MOVEMENT_TYPES.NONE ||(wall.data.door != 0 && wall.data.ds === 1)
+    }
+  }
+
+  /**
    * Perform a collision test between 2 point in 3D space
    * @param {Object} p0 - a point in 3d space {x:x,y:y,z:z} where z is the elevation
    * @param {Object} p1 - a point in 3d space {x:x,y:y,z:z} where z is the elevation
@@ -1956,25 +1967,10 @@ class Levels {
     function walls3dTest() {
       let terrainWalls = 0;
       for (let wall of canvas.walls.placeables) {
-        let isTerrain = false;
-        //continue if we have to ignore the wall
-        if (TYPE === 0) {
-          //sight
-          if (
-            wall.data.sight === CONST.WALL_SENSE_TYPES.NONE ||
-            (wall.data.door != 0 && wall.data.ds === 1)
-          )
-            continue;
-          if (wall.data.sight === CONST.WALL_SENSE_TYPES.LIMITED) isTerrain = true;
-        }
-        if (TYPE === 1) {
-          //collision
-          if (
-            wall.data.move === CONST.WALL_MOVEMENT_TYPES.NONE ||
-            (wall.data.door != 0 && wall.data.ds === 1)
-          )
-            continue;
-        }
+        if (_levels.shouldIgnoreWall(wall, TYPE)) continue;
+
+        let isTerrain = wall.data.sight === CONST.WALL_SENSE_TYPES.LIMITED;
+
         //declare points in 3d space of the rectangle created by the wall
         const wallBotTop = getWallHeightRange3Dcollision(wall);
         const wx1 = wall.data.c[0];

--- a/scripts/levels.js
+++ b/scripts/levels.js
@@ -1857,13 +1857,16 @@ class Levels {
   }
 
   /**
-  * Check whether the given wall should be tested for collisions
-  */
-   shouldIgnoreWall(wall, collisionType) {
+   * Check whether the given wall should be tested for collisions, based on the collision type and wall configuration
+   * @param {Object} wall - The wall being checked
+   * @param {Integer} collisionType - The collision type being checked: 0 for sight, 1 for movement
+   * @returns {boolean} Whether the wall should be ignored
+   */
+  shouldIgnoreWall(wall, collisionType) {
     if (collisionType === 0) {
       return wall.data.sight === CONST.WALL_SENSE_TYPES.NONE || (wall.data.door != 0 && wall.data.ds === 1)
     } else if (collisionType === 1) {
-      return wall.data.move === CONST.WALL_MOVEMENT_TYPES.NONE ||(wall.data.door != 0 && wall.data.ds === 1)
+      return wall.data.move === CONST.WALL_MOVEMENT_TYPES.NONE || (wall.data.door != 0 && wall.data.ds === 1)
     }
   }
 


### PR DESCRIPTION
I am developing a module ([Sense Walls](https://foundryvtt.com/packages/sense-walls)) that allows tokens to ignore walls based on certain conditions. At the moment, it is incompatible with Levels because Levels has its own function to calculate if a token is visible.

It isn't easy to override Level's function to ignore the wall because the calculation is done in `walls3dTest`, which also contains complicated maths part, which isn't ideal to override. In this PR, I've separated out the logic of whether to ignore the wall into its own function. Because the logic is now split up, I've managed to make the code a little tidier as well.

The refactored function is outside of the `testCollision` function so it can be overridden in modules using libWrapper. This is only a refactor, the logic itself (overriding modules notwithstanding) has not changed. This should also not break compatibility with any modules that already override `walls3dTest`.