### PR TITLE
Utilize Foundry V11 build in compendium folder structure

### DIFF
--- a/module.json
+++ b/module.json
@@ -48,6 +48,20 @@
   "styles": [
     "styles/levels.css"
   ],
+      "packFolders":[
+        {
+            "name": "Levels",
+            "sorting": "m",
+            "ownership": {
+              "PLAYER": "NONE",
+              "ASSISTANT": "OWNER"
+            },
+            "packs":[
+              "levelsmacros",
+              "maps"
+            ]
+          }
+    ],
   "packs": [
     {
       "name": "levelsmacros",


### PR DESCRIPTION
Utilize Foundry V11 build in compendium folder structure to reduce clutter on the compendium tab

![obraz](https://github.com/theripper93/Levels/assets/30767613/ff2401c3-5f41-4ce7-acc2-7dd8ab5f5400)
